### PR TITLE
Added support for :vert option when requesting heroes portraits

### DIFF
--- a/lib/dota/api/hero.rb
+++ b/lib/dota/api/hero.rb
@@ -12,7 +12,13 @@ module Dota
       end
 
       def image_url(type = :full)
-        "http://cdn.dota2.com/apps/dota2/images/heroes/#{internal_name}_#{type}.png"
+        # Possible values for type:
+        # :full - full quality horizontal portrait (256x114px, PNG)
+        # :lg - large horizontal portrait (205x11px, PNG)
+        # :sb - small horizontal portrait (59x33px, PNG)
+        # :vert - full quality vertical portrait (234x272px, JPEG)
+
+        "http://cdn.dota2.com/apps/dota2/images/heroes/#{internal_name}_#{type}.#{type == :vert ? 'jpg' : 'png'}"
       end
 
       private


### PR DESCRIPTION
It appears that hero's portrait with the "vert" type has to be JPG (strangely enough). This https://steamcdn-a.akamaihd.net/apps/dota2/images/heroes/leshrac_vert.png is not working however https://steamcdn-a.akamaihd.net/apps/dota2/images/heroes/leshrac_vert.jpg this does. Also check here http://dev.dota2.com/showthread.php?t=58317 ("heroes" section).