### PR TITLE
An empty array should be returned if no units/abilities upgrades is …

### DIFF
--- a/lib/dota/api/match/player.rb
+++ b/lib/dota/api/match/player.rb
@@ -36,11 +36,15 @@ module Dota
         end
 
         def additional_units
-          raw["additional_units"].map { |unit| Unit.new(unit["unitname"], extract_items_from(unit)) }
+          raw["additional_units"] ?
+            raw["additional_units"].map { |unit| Unit.new(unit["unitname"], extract_items_from(unit)) } :
+            []
         end
 
         def ability_upgrades
-          raw["ability_upgrades"].map { |ability_upgrade| AbilityUpgrade.new(ability_upgrade) }
+          raw["ability_upgrades"] ?
+            raw["ability_upgrades"].map { |ability_upgrade| AbilityUpgrade.new(ability_upgrade) } :
+            []
         end
 
         def items


### PR DESCRIPTION
…found

That's a pretty serious stuff that basically breaks the app when trying to load a match where someone has no ability upgrades or summoned units.